### PR TITLE
bug fix in Opticalflow: earlier the image was getting transposed

### DIFF
--- a/OpticalFlow2D.lua
+++ b/OpticalFlow2D.lua
@@ -28,10 +28,10 @@ function OpticalFlow2D:__init(height, width)
    
    self.baseGrid = torch.Tensor(height, width, 2)
    for i=1,self.height do
-      self.baseGrid:select(3,2):select(1,i):fill(-1 + (i-1)/(self.height-1) * 2)
+      self.baseGrid:select(3,1):select(1,i):fill(-1 + (i-1)/(self.height-1) * 2)
    end
    for j=1,self.width do
-      self.baseGrid:select(3,1):select(2,j):fill(-1 + (j-1)/(self.width-1) * 2)
+      self.baseGrid:select(3,2):select(2,j):fill(-1 + (j-1)/(self.width-1) * 2)
    end
 
    self.batchGrid = torch.Tensor(1, height, width, 2):copy(self.baseGrid)


### PR DESCRIPTION
I think there is a Bug in Opticalflow2D. The image after applying the optical flow using BilinearSamplerBHWD is transposed (x and y axes interchanged). The reason being error in self.baseGrid calculation. I have updated that. Please review. 

Thanks
Ruppesh